### PR TITLE
Potential performance improvement for checking Component requirements

### DIFF
--- a/engine/core/component.lua
+++ b/engine/core/component.lua
@@ -13,17 +13,10 @@ Component.requirements = {}
 --- @param entity Entity The actor to check the requirements against.
 --- @return boolean meetsRequirements the actor meets all requirements, false otherwise.
 function Component:checkRequirements(entity)
-   local foundreqs = {}
-
-   for _, component in pairs(entity.components) do
-      for _, requirement in pairs(self.requirements) do
-         if component.className == requirement then table.insert(foundreqs, component) end
-      end
+   for _, requirement in pairs(self.requirements) do
+      if entity.componentClassNames[requirement.className] == nil then return false end
    end
-
-   if #foundreqs == #self.requirements then return true end
-
-   return false
+   return true
 end
 
 return Component

--- a/engine/core/entity.lua
+++ b/engine/core/entity.lua
@@ -14,6 +14,7 @@ function Entity:__new()
    local components = self:initialize()
    self.components = {}
    self.componentCache = {}
+   self.componentClassNames = {}
    if components then
       for _, component in ipairs(components) do
          component.owner = self
@@ -50,6 +51,7 @@ function Entity:addComponent(component)
 
    component.owner = self
    table.insert(self.components, component)
+   self.componentClassNames[component.className] = true
 end
 
 --- Removes a component from the entity. This function will throw an error if the


### PR DESCRIPTION
Resolves #109 

Use a cache to improve component requirement checking performance. This assumes that component requirements are by component type (via class name in this case) and not by instance.