### PR TITLE
Switch to factories for entities

### DIFF
--- a/engine/core/action.lua
+++ b/engine/core/action.lua
@@ -24,7 +24,7 @@ function Action:__validateTargets()
    if #self.targetObjects ~= #self.targets then
       return false,
          "Invalid number of targets for action "
-            .. self.name
+            .. self.className
             .. " expected "
             .. #self.targets
             .. " got "
@@ -34,7 +34,7 @@ function Action:__validateTargets()
    for i = 1, #self.targets do
       local target = self.targets[i]
       if not target:validate(self.owner, self.targetObjects[i], self.targetObjects) then
-         return false, "Invalid target " .. i .. " for action " .. self.name
+         return false, "Invalid target " .. i .. " for action " .. self.className
       end
    end
 
@@ -58,7 +58,7 @@ function Action:hasRequisiteComponents(actor)
    if not self.requiredComponents then return true end
 
    for _, component in pairs(self.requiredComponents) do
-      if not actor:has(component) then return false, component.name end
+      if not actor:has(component) then return false, component.className end
    end
 
    return true

--- a/engine/core/actor.lua
+++ b/engine/core/actor.lua
@@ -8,7 +8,6 @@
 --- @overload fun(): Actor
 local Actor = prism.Entity:extend("Actor")
 Actor.position = nil
-Actor.name = "actor"
 
 --- @alias ActorFactory fun(): Actor
 

--- a/engine/core/actor.lua
+++ b/engine/core/actor.lua
@@ -10,6 +10,8 @@ local Actor = prism.Entity:extend("Actor")
 Actor.position = nil
 Actor.name = "actor"
 
+--- @alias ActorFactory fun(): Actor
+
 --- Constructor for an actor.
 --- Initializes and copies the actor's fields from its prototype.
 --- @param self Actor
@@ -54,6 +56,17 @@ end
 --- @return Component[]
 function Actor:initialize()
    return {}
+end
+
+--- Initializes an actor from a list of components.
+--- @param components Component[] A list of components to give to the new actor.
+--- @return Actor actor The new actor.
+function Actor.fromComponents(components)
+   local actor = Actor()
+   for _, component in ipairs(components) do
+      actor:give(component)
+   end
+   return actor
 end
 
 --

--- a/engine/core/actor.lua
+++ b/engine/core/actor.lua
@@ -9,7 +9,7 @@
 local Actor = prism.Entity:extend("Actor")
 Actor.position = nil
 
---- @alias ActorFactory fun(): Actor
+--- @alias ActorFactory fun(...): Actor
 
 --- Constructor for an actor.
 --- Initializes and copies the actor's fields from its prototype.

--- a/engine/core/cell.lua
+++ b/engine/core/cell.lua
@@ -6,9 +6,22 @@
 --- @overload fun(): Cell
 local Cell = prism.Entity:extend("Cell")
 
+--- @alias CellFactory fun(): Cell
+
 --- Constructor for the Cell class.
 function Cell:__new()
    prism.Entity.__new(self)
+end
+
+--- Initializes a cell from a list of components.
+--- @param components Component[] A list of components to give to the new cell.
+--- @return Cell cell The new actor.
+function Cell.fromComponents(components)
+   local cell = Cell()
+   for _, component in ipairs(components) do
+      cell:give(component)
+   end
+   return cell
 end
 
 --- @return Bitmask mask The collision mask of the cell.

--- a/engine/core/components/name.lua
+++ b/engine/core/components/name.lua
@@ -1,0 +1,10 @@
+--- A display name for an entity.
+--- @class Name : Component
+--- @overload fun(name: string): Name
+local Name = prism.Component:extend "Name"
+
+function Name:__new(name)
+   self.name = name
+end
+
+return Name

--- a/engine/core/entity.lua
+++ b/engine/core/entity.lua
@@ -11,26 +11,13 @@ local Entity = prism.Object:extend("Entity")
 function Entity:__new()
    self.position = prism.Vector2(1, 1)
 
-   local components = self:initialize()
    self.components = {}
    self.componentCache = {}
-   if components then
-      for _, component in ipairs(components) do
-         component.owner = self
-         self:give(component)
-      end
-   end
 end
 
 --
 --- Components
 --
-
---- Creates the components for the entity. Override this.
---- @return Component[]
-function Entity:initialize()
-   return {}
-end
 
 --- Adds a component to the entity, replacing any existing component of the same type. Will check if the component's
 --- prerequisites are met and will throw an error if they are not.

--- a/engine/core/entity.lua
+++ b/engine/core/entity.lua
@@ -31,7 +31,7 @@ function Entity:give(component)
    if not requirementsMet then
       --- @cast missingComponent Component
       local err = "%s was missing requirement %s for %s"
-      error(err:format(self.name, missingComponent.name, component.name))
+      error(err:format(self.className, missingComponent.className, component.className))
    end
 
    -- Set the component for all sub-classes
@@ -55,7 +55,7 @@ function Entity:remove(component)
 
    if not self:has(component) then
       -- stylua: ignore
-      prism.logger.warn("Tried to remove " .. component.name .. " from " .. self.name .. " but they didn't have it.")
+      prism.logger.warn("Tried to remove " .. component.className .. " from " .. self:getName() .. " but they didn't have it.")
       return self
    end
 
@@ -114,6 +114,13 @@ function Entity:get(prototype, ...)
    if prototype == nil then return nil end
 
    return self.componentCache[prototype], self:get(...)
+end
+
+--- Returns the entity's name from their Name component, or the className if it doesn't have one.
+--- @return string
+function Entity:getName()
+   local name = self:get(prism.components.Name)
+   return name and name.name or self.className
 end
 
 --- Expects a component, returning it or erroring if the entity does not have the component.

--- a/engine/core/level.lua
+++ b/engine/core/level.lua
@@ -47,7 +47,7 @@ end
 function Level:initialize(actors, systems)
    assert(#actors > 0, "A level must be initialized with at least one actor!")
 
-   prism.logger.debug("Level is initializing with", #actors, " actors and", #systems, " systems...")
+   prism.logger.debug("Level is initializing with", #actors, "actors and", #systems, "systems...")
 
    self:initializeOpacityCache()
    self:initializePassabilityCache()
@@ -140,7 +140,7 @@ end
 --- the system has a requirement that hasn't been attached yet.
 --- @param system System The system to add.
 function Level:addSystem(system)
-   prism.logger.debug("System", system.name, "was added to level")
+   prism.logger.debug("System", system.className, "was added to level")
    self.systemManager:addSystem(system)
 end
 
@@ -169,7 +169,7 @@ end
 --- scheduler if it has a controller.
 --- @param actor Actor The actor to add.
 function Level:addActor(actor)
-   prism.logger.debug("Actor", actor.name, "was added to level")
+   prism.logger.debug("Actor", actor:getName(), "was added to level")
    actor.level = self
 
    self.actorStorage:addActor(actor)
@@ -183,7 +183,7 @@ end
 --- the scheduler if it has a controller.
 --- @param actor Actor The actor to remove.
 function Level:removeActor(actor)
-   prism.logger.debug("Actor", actor.name, "was removed from level")
+   prism.logger.debug("Actor", actor:getName(), "was removed from level")
    actor.level = nil
    self.actorStorage:removeActor(actor)
    self.scheduler:remove(actor)
@@ -275,7 +275,7 @@ function Level:perform(action, silent)
    assert(self:canPerform(action))
    local owner = action.owner
 
-   prism.logger.debug("Actor", owner.name, "is about to perform", action.name)
+   prism.logger.debug("Actor", owner:getName(), "is about to perform", action.className)
    if not silent then self.systemManager:beforeAction(self, owner, action) end
    ---@diagnostic disable-next-line
    action:perform(self, unpack(action.targetObjects))

--- a/engine/core/level.lua
+++ b/engine/core/level.lua
@@ -361,9 +361,9 @@ end
 --- @param x number The x component of the position to check.
 --- @param y number The y component of the position to check.
 --- @param mask Bitmask The collision mask for checking passability.
---- @param size integer The size of the actor.
+--- @param size? integer The size of the actor.
 function Level:getCellPassable(x, y, mask, size)
-   local cellMask = self.passableCache:getMask(x, y, size)
+   local cellMask = self.passableCache:getMask(x, y, size or 1)
    return prism.Collision.checkBitmaskOverlap(mask, cellMask)
 end
 
@@ -485,11 +485,8 @@ end
 ---@param distanceType? DistanceType An optional distance type to use for calculating the minimum distance. Defaults to prism._defaultDistance.
 ---@return Path? path A path to the goal, or nil if a path could not be found or the start is already at the minimum distance.
 function Level:findPath(start, goal, actor, mask, minDistance, distanceType)
-   if
-      not self.map:isInBounds(start.x, start.y) 
-      or not self.map:isInBounds(goal.x, goal.y)
-   then
-     return
+   if not self.map:isInBounds(start.x, start.y) or not self.map:isInBounds(goal.x, goal.y) then
+      return
    end
 
    local collider = actor:get(prism.components.Collider)

--- a/engine/core/map.lua
+++ b/engine/core/map.lua
@@ -16,7 +16,7 @@ Map.serializationBlacklist = {
 --- @param h number The height of the map.
 --- @param cellPrototype Cell The initial value to fill the map with.
 function Map:__new(w, h, cellPrototype)
-   assert(not cellPrototype:isInstance(), "Map constructor expects a prototype!")
+   -- assert(not cellPrototype:isInstance(), "Map constructor expects a prototype!")
 
    prism.Grid.__new(self, w, h, cellPrototype)
 

--- a/engine/core/map_builder.lua
+++ b/engine/core/map_builder.lua
@@ -37,7 +37,7 @@ end
 --- @param y2 number The y-coordinate of the bottom-right corner.
 --- @param cellPrototype Cell The cell (prototype) to fill the rectangle with.
 function MapBuilder:drawRectangle(x1, y1, x2, y2, cellPrototype)
-   assert(not cellPrototype:isInstance(), "drawRectangle expects a prototype, not an instance!")
+   -- assert(not cellPrototype:isInstance(), "drawRectangle expects a prototype, not an instance!")
 
    for x = x1, x2 do
       for y = y1, y2 do
@@ -53,7 +53,7 @@ end
 --- @param ry number The radius along the y-axis.
 --- @param cellPrototype Cell The cell (prototype) to fill the ellipse with.
 function MapBuilder:drawEllipse(cx, cy, rx, ry, cellPrototype)
-   assert(not cellPrototype:isInstance(), "drawEllipse expects a prototype, not an instance!")
+   -- assert(not cellPrototype:isInstance(), "drawEllipse expects a prototype, not an instance!")
 
    for x = -rx, rx do
       for y = -ry, ry do
@@ -71,7 +71,7 @@ end
 --- @param y2 number The y-coordinate of the ending point.
 --- @param cellPrototype Cell The cell (prototype) to draw the line with.
 function MapBuilder:drawLine(x1, y1, x2, y2, cellPrototype)
-   assert(not cellPrototype:isInstance(), "drawEllipse expects a prototype, not an instance!")
+   -- assert(not cellPrototype:isInstance(), "drawEllipse expects a prototype, not an instance!")
 
    local dx = math.abs(x2 - x1)
    local dy = math.abs(y2 - y1)
@@ -130,7 +130,7 @@ end
 --- @param width number The width of the padding to add.
 --- @param cellPrototype Cell The cell (prototype) to use for padding.
 function MapBuilder:addPadding(width, cellPrototype)
-   assert(not cellPrototype:isInstance(), "addPadding expects a prototype, not an instance!")
+   -- assert(not cellPrototype:isInstance(), "addPadding expects a prototype, not an instance!")
 
    local minX, minY = math.huge, math.huge
    local maxX, maxY = -math.huge, -math.huge

--- a/engine/core/object.lua
+++ b/engine/core/object.lua
@@ -136,7 +136,7 @@ function Object:mixin(mixin)
 end
 
 function Object:__tostring()
-   return "Hello"
+   return self.name
 end
 
 function Object.serialize(object)

--- a/engine/core/object.lua
+++ b/engine/core/object.lua
@@ -136,7 +136,7 @@ function Object:mixin(mixin)
 end
 
 function Object:__tostring()
-   return self.name
+   return "Hello"
 end
 
 function Object.serialize(object)

--- a/engine/core/object.lua
+++ b/engine/core/object.lua
@@ -4,7 +4,6 @@ prism._ISCLASS = {}
 --- A simple class system for Lua. This is the base class for all other classes in PRISM.
 ---@class Object
 ---@field className string (static) A unique name for this class. By convention this should match the annotation name you use.
----@field name string An optional display name. Defaults to the className.
 ---@field private stripName boolean
 ---@field private _isInstance boolean
 ---@field serializationBlacklist table<string, boolean>
@@ -30,7 +29,6 @@ function Object:extend(className, ignoreclassName)
    self.__index = self
    self.__call = self.__call or Object.__call
    o._isInstance = false
-   o.name = className
    o.className = className
 
    --print(className, not ignoreclassName, not prism._OBJECTREGISTRY[className])
@@ -133,10 +131,6 @@ function Object:mixin(mixin)
    end
 
    return self
-end
-
-function Object:__tostring()
-   return self.name
 end
 
 function Object.serialize(object)

--- a/engine/init.lua
+++ b/engine/init.lua
@@ -196,6 +196,9 @@ prism.components.Senses = prism.require "core.components.senses"
 --- @module "engine.core.components.opaque"
 prism.components.Opaque = prism.require "core.components.opaque"
 
+--- @module "engine.core.components.name"
+prism.components.Name = prism.require "core.components.name"
+
 --- @module "engine.core.decisions.actiondecision"
 prism.decisions.ActionDecision = prism.require "core.decisions.actiondecision"
 
@@ -236,7 +239,7 @@ function prism.registerCell(name, factory)
    prism.cells[name] = factory
 
    if prism._currentDefinitions then
-      table.insert(prism._currentDefinitions, "--- @type fun(): Cell")
+      table.insert(prism._currentDefinitions, "--- @type fun(...): Cell")
       table.insert(prism._currentDefinitions, "prism.cells." .. name .. " = nil")
    end
 end
@@ -248,7 +251,7 @@ function prism.registerActor(name, factory)
    prism.actors[name] = factory
 
    if prism._currentDefinitions then
-      table.insert(prism._currentDefinitions, "--- @type fun(): Actor")
+      table.insert(prism._currentDefinitions, "--- @type fun(...): Actor")
       table.insert(prism._currentDefinitions, "prism.actors." .. name .. " = nil")
    end
 end
@@ -359,7 +362,7 @@ function prism.turn(level, actor, controller)
    action = controller:act(level, actor)
 
    -- we make sure we got an action back from the controller for sanity's sake
-   assert(action, "Actor " .. actor.name .. " returned nil from act()")
+   assert(action, "Actor " .. actor:getName() .. " returned nil from act()")
 
    level:perform(action)
 end

--- a/geometer/editor.lua
+++ b/geometer/editor.lua
@@ -2,7 +2,7 @@
 local keybinds = geometer.require "keybindingschema"
 local PenTool = geometer.require "tools.pen"
 
----@alias Placeable Entity
+---@alias Placeable { entity: Entity, factory: fun(): Entity }
 
 ---@class Editor : Object
 ---@field attachable SpectrumAttachable

--- a/geometer/elements/selectiongrid.lua
+++ b/geometer/elements/selectiongrid.lua
@@ -4,8 +4,9 @@ local Inky = geometer.require "inky"
 ---@field placeable Placeable
 ---@field size Vector2 the final size of a tile in editor
 ---@field display Display
----@field onSelect function
+---@field onSelect fun(index: number)
 ---@field overlay love.Texture
+---@field index integer
 
 ---@class TileElement : Inky.Element
 ---@field props TileElementProps
@@ -19,7 +20,7 @@ local function Tile(self, scene)
    )
 
    self:onPointer("press", function()
-      self.props.onSelect(self.props.placeable)
+      self.props.onSelect(self.props.index)
    end)
 
    self:onPointerEnter(function()
@@ -31,7 +32,7 @@ local function Tile(self, scene)
    end)
 
    return function(_, x, y, w, h)
-      local drawable = self.props.placeable:get(prism.components.Drawable)
+      local drawable = self.props.placeable.entity:get(prism.components.Drawable)
       local quad = self.props.display:getQuad(drawable.index)
 
       love.graphics.push("all")
@@ -64,7 +65,7 @@ local TileElement = Inky.defineElement(Tile)
 ---@class SelectionGridProps : Inky.Props
 ---@field size Vector2 the final size of a tile in editor
 ---@field display Display
----@field onSelect function
+---@field onSelect fun(index: number)
 ---@field overlay love.Texture
 ---@field placeables Placeable[]
 ---@field elements TileElement[]
@@ -87,22 +88,23 @@ local function SelectionGrid(self, scene)
    resetRange()
 
    local upOnSelect = self.props.onSelect
-   self.props.onSelect = function(placeable)
-      self.props.selected = placeable
-      upOnSelect(placeable)
+   self.props.onSelect = function(index)
+      self.props.selected = self.props.placeables[index]
+      upOnSelect(index)
    end
 
    self.props.elements = {}
-   for _, placeable in ipairs(self.props.placeables) do
+   for index, placeable in ipairs(self.props.placeables) do
       local tile = TileElement(scene)
       tile.props.display = self.props.display
+      tile.props.index = index
       tile.props.onSelect = self.props.onSelect
       tile.props.overlay = self.props.overlay
       tile.props.size = self.props.size
       tile.props.placeable = placeable
       table.insert(self.props.elements, tile)
    end
-   self.props.onSelect(self.props.placeables[1])
+   self.props.onSelect(1)
 
    self:useEffect(function()
       resetRange()

--- a/geometer/elements/selectionpanel.lua
+++ b/geometer/elements/selectionpanel.lua
@@ -41,7 +41,7 @@ local function SelectionPanel(self, scene)
    local function onSelect(index)
       local placeable = self.props.placeables[index]
       self.props.selected = placeable
-      self.props.selectedText:set(placeable.entity.name)
+      self.props.selectedText:set(placeable.entity:getName())
 
       -- We use the prototype so we can instantiate them into the level
       self.props.editor.placeable = placeable

--- a/geometer/elements/selectionpanel.lua
+++ b/geometer/elements/selectionpanel.lua
@@ -88,7 +88,8 @@ local function SelectionPanel(self, scene)
    textInput.props.onEdit = function(content)
       local filtered = {}
       for i, placeable in ipairs(self.props.placeables) do
-         if placeable.entity.name:find(content) then table.insert(filtered, i) end
+         local upper = string.upper(content)
+         if placeable.entity:getName():upper():find(upper) then table.insert(filtered, i) end
       end
       self.props.filtered = filtered
       grid.props.filtered = filtered

--- a/geometer/elements/selectionpanel.lua
+++ b/geometer/elements/selectionpanel.lua
@@ -9,12 +9,12 @@ local Button = geometer.require "elements.button"
 ---@return Placeable[]
 local function initialElements()
    local t = {}
-   for _, cell in pairs(prism.cells) do
-      table.insert(t, cell())
+   for _, cellFactory in pairs(prism.cells) do
+      table.insert(t, { entity = cellFactory(), factory = cellFactory })
    end
 
-   for _, actor in pairs(prism.actors) do
-      table.insert(t, actor())
+   for _, actorFactory in pairs(prism.actors) do
+      table.insert(t, { entity = actorFactory(), factory = actorFactory })
    end
 
    return t
@@ -37,13 +37,14 @@ end
 ---@param scene Inky.Scene
 ---@return function
 local function SelectionPanel(self, scene)
-   ---@param placeable Placeable
-   local function onSelect(placeable)
+   ---@param index integer
+   local function onSelect(index)
+      local placeable = self.props.placeables[index]
       self.props.selected = placeable
-      self.props.selectedText:set(placeable.name)
+      self.props.selectedText:set(placeable.entity.name)
 
       -- We use the prototype so we can instantiate them into the level
-      self.props.editor.placeable = getmetatable(placeable)
+      self.props.editor.placeable = placeable
    end
 
    -- We capture and consume pointer events to avoid the editor grid consuming them,
@@ -87,7 +88,7 @@ local function SelectionPanel(self, scene)
    textInput.props.onEdit = function(content)
       local filtered = {}
       for i, placeable in ipairs(self.props.placeables) do
-         if placeable.name:find(content) then table.insert(filtered, i) end
+         if placeable.entity.name:find(content) then table.insert(filtered, i) end
       end
       self.props.filtered = filtered
       grid.props.filtered = filtered
@@ -115,7 +116,7 @@ local function SelectionPanel(self, scene)
       clearButton:render(x + 8 * 11, y + 2 * 8, 8, 8, depth + 2)
       grid:render(x, y + 5 * 8, w, 8 * 12, depth + 1)
 
-      local drawable = self.props.selected:get(prism.components.Drawable)
+      local drawable = self.props.selected.entity:get(prism.components.Drawable)
       local quad = self.props.display:getQuad(drawable.index)
       local scale = prism.Vector2(
          self.props.size.x / self.props.display.cellSize.x,

--- a/geometer/modification.lua
+++ b/geometer/modification.lua
@@ -49,25 +49,24 @@ end
 --- @param attachable SpectrumAttachable
 --- @param x integer
 --- @param y integer
---- @param entityPrototype Entity
-function Modification:place(attachable, x, y, entityPrototype)
-   if prism.Actor:is(entityPrototype) then
-      --- @cast entityPrototype Actor
-      self:placeActor(attachable, x, y, entityPrototype)
+--- @param placeable Placeable
+function Modification:place(attachable, x, y, placeable)
+   if prism.Actor:is(placeable.entity) then
+      self:placeActor(attachable, x, y, placeable)
    else
-      --- @cast entityPrototype Cell
-      self:placeCell(attachable, x, y, entityPrototype)
+      self:placeCell(attachable, x, y, placeable)
    end
 end
 
 --- @param attachable SpectrumAttachable
 --- @param x integer
 --- @param y integer
---- @param actorPrototype Actor
-function Modification:placeActor(attachable, x, y, actorPrototype)
+--- @param placeable Placeable
+function Modification:placeActor(attachable, x, y, placeable)
    if not self.placed then self.placed = {} end
 
-   local instance = actorPrototype()
+   local instance = placeable.factory()
+   --- @cast instance Actor
 
    --- @diagnostic disable-next-line
    instance.position = prism.Vector2(x, y)
@@ -79,11 +78,11 @@ end
 ---@param attachable SpectrumAttachable
 ---@param x integer
 ---@param y integer
----@param cellPrototype Cell|nil
-function Modification:placeCell(attachable, x, y, cellPrototype)
+---@param placeable Placeable
+function Modification:placeCell(attachable, x, y, placeable)
    if not self.replaced then self.replaced = prism.SparseGrid() end
-   local instance = cellPrototype
-   if cellPrototype then instance = cellPrototype() end
+   local instance = placeable.factory()
+   --- @cast instance Cell
 
    self.replaced:set(x, y, attachable:getCell(x, y) or false)
    attachable:setCell(x, y, instance)

--- a/geometer/tool.lua
+++ b/geometer/tool.lua
@@ -21,7 +21,7 @@ end
 ---@param placeable Placeable
 ---@return Drawable
 function Tool:getDrawable(placeable)
-   placeable = placeable()
+   placeable = placeable.entity
    return placeable:get(prism.components.Drawable)
 end
 

--- a/spectrum/components/drawable.lua
+++ b/spectrum/components/drawable.lua
@@ -4,17 +4,17 @@
 --- @field color Color4
 --- @field background Color4
 --- @field size integer
---- @overload fun(index: string|integer, color: Color4?, size:integer?, background: Color4?, layer: number?): Drawable
+--- @overload fun(index: string|integer, color: Color4?, background: Color4?, layer: number?, size: integer?): Drawable
 local Drawable = prism.Component:extend "Drawable"
 
 --- Index needs to be a string associated with a sprite in the SpriteAtlas, or
 --- an integer index associated with a sprite.
 --- @param index string|integer
 --- @param color Color4?
---- @param size integer?
 --- @param background Color4?
 --- @param layer integer?
-function Drawable:__new(index, color, size, background, layer)
+--- @param size integer?
+function Drawable:__new(index, color, background, layer, size)
    self.index = index
    self.color = color or prism.Color4.WHITE
    self.background = background or prism.Color4.TRANSPARENT


### PR DESCRIPTION
Rather than extending `Cell` and Actor` to define actor "archetypes", you now instead register simple factories that return new actors. Of course, these factories can also accept parameters, though adding types to the definitions is not really supported. This also means you could register multiple actors or cells in the same file to compose them. Overall this tries to divorce "types" from entities, as they should only differ by their components. 

Example player factory registration:

```lua
-- modules/game/player.lua
prism.registerActor("Player", function(index)
   return prism.Actor.fromComponents {
      prism.components.Name("Player"),
      prism.components.Drawable("@", prism.Color4.GREEN),
      prism.components.Collider(),
      prism.components.PlayerController(),
      prism.components.Senses(),
      prism.components.Sight { range = 64, fov = true },
      prism.components.Mover { "walk" },
   }
end)

```

`Object.name` was also removed entirely, in favour of a `Name` component for entities. We'll probably extend this with localization support later? 