### PR TITLE
Use utf8.char instead of string.char to support UTF-8

### DIFF
--- a/docs/source/making-a-roguelike/part10.rst
+++ b/docs/source/making-a-roguelike/part10.rst
@@ -50,6 +50,7 @@ Finally we create a mapping of letters from 1-26 corresponding to a-z which we'l
 
 .. code:: lua
 
+   local utf8 = require "utf8"
    local keybindings = require "keybindingschema"
 
    --- @class InventoryState : GameState
@@ -68,7 +69,7 @@ Finally we create a mapping of letters from 1-26 corresponding to a-z which we'l
       self.items = inventory.inventory:getAllActors()
       self.letters = {}
       for i = 1, #self.items do
-         self.letters[i] = string.char(96 + i) -- a, b, c, ...
+         self.letters[i] = utf8.char(96 + i) -- a, b, c, ...
       end
    end
 

--- a/spectrum/spriteatlas.lua
+++ b/spectrum/spriteatlas.lua
@@ -1,3 +1,5 @@
+local utf8 = require "utf8"
+
 --- A simple sprite atlas. Used by spectrum.Display to render cells and actors.
 ---@class SpriteAtlas : Object
 ---@field image any The texture atlas love image
@@ -108,8 +110,8 @@ function SpriteAtlas.fromGrid(imagePath, cellWidth, cellHeight, names)
    return SpriteAtlas(imagePath, spriteData, names)
 end
 
---- Creates a SpriteAtlas from a grid of cells, mapping each quad to an ASCII character.
---- The first quad is mapped to string.char(startingCode), e.g. 'A' for 65, ' ' for 32.
+--- Creates a SpriteAtlas from a grid of cells, mapping each quad to a UTF-8 character.
+--- The first quad is mapped to utf8.char(startingCode), e.g. 'A' for 65, ' ' for 32.
 --- @param imagePath string The path to the texture atlas image.
 --- @param cellWidth number The width of each cell in the grid.
 --- @param cellHeight number The height of each cell in the grid.
@@ -125,7 +127,7 @@ function SpriteAtlas.fromASCIIGrid(imagePath, cellWidth, cellHeight)
    local names = {}
 
    for i = 1, totalCells do
-      names[i] = string.char(i - 1)
+      names[i] = utf8.char(i - 1)
    end
 
    return SpriteAtlas.fromGrid(imagePath, cellWidth, cellHeight, names)


### PR DESCRIPTION
Now you can use `SpriteAtlas.fromASCIIGrid` on a tilesheet with more than 256 sprites.