### PR TITLE
Enhancement/add actor coordinates

### DIFF
--- a/engine/core/level.lua
+++ b/engine/core/level.lua
@@ -173,11 +173,11 @@ end
 --- @param y integer? The y coordinate to place the actor at.
 function Level:addActor(actor, x, y)
    if x and y then
-      if actor:has(prism.components.Position) then
+      if actor:getPosition() then
          actor:give(prism.components.Position(prism.Vector2(x, y)))
       else
          prism.logger.warn(
-            "Attempted to add", actor:getName(),
+            "Attempted to add", actor:getName(), "to level",
             "at position", x, ",", y, "but it did not have a position component!"
          )
       end

--- a/engine/core/level.lua
+++ b/engine/core/level.lua
@@ -169,7 +169,20 @@ end
 --- inserting the actor into the sparse map. It will also add the actor to the
 --- scheduler if it has a controller.
 --- @param actor Actor The actor to add.
-function Level:addActor(actor)
+--- @param x integer? The x coordinate to place the actor at.
+--- @param y integer? The y coordinate to place the actor at.
+function Level:addActor(actor, x, y)
+   if x and y then
+      if actor:has(prism.components.Position) then
+         actor:give(prism.components.Position(prism.Vector2(x, y)))
+      else
+         prism.logger.warn(
+            "Attempted to add", actor:getName(),
+            "at position", x, ",", y, "but it did not have a position component!"
+         )
+      end
+   end
+
    prism.logger.debug("Actor", actor:getName(), "was added to level")
    actor.level = self
 

--- a/engine/core/map_builder.lua
+++ b/engine/core/map_builder.lua
@@ -19,8 +19,15 @@ end
 --- @param x number? The x-coordinate.
 --- @param y number? The y-coordinate.
 function MapBuilder:addActor(actor, x, y)
-   if x and y and actor:getPosition() then
-      actor:give(prism.components.Position(prism.Vector2(x, y)))
+   if x and y then
+      if actor:getPosition() then
+         actor:give(prism.components.Position(prism.Vector2(x, y)))
+      else
+         prism.logger.warn(
+            "Attempted to add", actor:getName(), "to mapbuilder",
+            "at position", x, ",", y, "but it did not have a position component!"
+         )
+      end
    end
 
    self.actors:addActor(actor)


### PR DESCRIPTION
Added an optional x,y pair to Level:addActor. Added a log warning when trying to set an Actor's position that has no position component in both Level:addActor and MapBuilder:addActor.

Once merged closes #152 