### PR TITLE
Added generations to the sparsearray.

### DIFF
--- a/engine/structures/sparsearray.lua
+++ b/engine/structures/sparsearray.lua
@@ -69,8 +69,6 @@ function SparseArray:get(handle)
    local index, gen = unpack_handle(handle)
    if self.generations[index] == gen then
       return self.data[index]
-   else
-      return nil
    end
 end
 


### PR DESCRIPTION
This PR adds generations to the SparseArray meaning that even reused slots in the sparsearray have unique handles or 'ids' as they're called in the code now. This is done to support work on buffs.

A few things to note:

Both the index and generation are packed into the 53 bits of the double precision floating point numbers that Lua uses, which means that we are limited to:

4,294,967,296 entries
2,097,152 rewrites per entry

I -sincerely- doubt that this will ever become an issue. You'd have to add and remove billions of actors from a level to run into this limit and that's just ridiculous.

The motivation for this change is how I'm planning on doing buffs where there's a central BuffContainer component which you register BuffInstances to and each has a list of StatModifiers. This would then be queried within other actions, usually through utility functions.

This means an effect or action could add a BuffInstance and get a unique handle to that instance back from the SparseArray and even if that BuffInstance is removed elsewhere, such as in a system which removed it because it's duration ran out, this handle will still be unique to that particular instance and has no chance of being removed when the handle goes stale, instead failing to remove it silently.

I also removed a bit of dead code.