### PR TITLE
Change display to use updateMode

### DIFF
--- a/spectrum/display.lua
+++ b/spectrum/display.lua
@@ -345,7 +345,7 @@ function Display:fitWindowToTerminal()
    local cellWidth, cellHeight = self.cellSize.x, self.cellSize.y
    local windowWidth = self.width * cellWidth
    local windowHeight = self.height * cellHeight
-   love.window.setMode(windowWidth, windowHeight, { resizable = true, usedpiscale = false })
+   love.window.updateMode(windowWidth, windowHeight, { resizable = true, usedpiscale = false })
 end
 
 --- Calculates the top-left offset needed to center a given position on the display.


### PR DESCRIPTION
`updateMode` preserves any flags not specified, which I think we want.

In my case the `displayIndex` specified in conf was being overwritten and this is why.