### PR TITLE
Pressing ` toggles editor

### DIFF
--- a/geometer/gamestates/editorstate.lua
+++ b/geometer/gamestates/editorstate.lua
@@ -51,6 +51,7 @@ function EditorState:mousereleased(x, y, button)
 end
 
 function EditorState:keypressed(key, scancode)
+   if key == "`" then self.manager:pop() return end
    self.editor:keypressed(key, scancode)
 end
 


### PR DESCRIPTION
Pressing ` while in Geometer closes it.