### PR TITLE
feat: improve action API (breaking change)

### DIFF
--- a/engine/core/action.lua
+++ b/engine/core/action.lua
@@ -7,7 +7,7 @@
 --- @field protected targets Target[] (static) A list of targets to apply the action to.
 --- @field protected targetObjects Object[] The objects that correspond to the targets.
 --- @field protected requiredComponents Component[] (static) Components required for an actor to take this action.
---- @field protected reaction boolean 
+--- @field protected reaction boolean
 --- @field protected abstract boolean
 --- @overload fun(owner: Actor, targets: Object[]): Action
 local Action = prism.Object:extend("Action")
@@ -18,7 +18,7 @@ Action.targets = {}
 ---@param ... Object An optional list of target actors. Not all actions require targets.
 function Action:__new(owner, ...)
    assert(owner, "Actions must have an owner!")
-   
+
    self.owner = owner
    self.targets = self.targets or {}
    self.targetObjects = { ... }
@@ -35,7 +35,13 @@ end
 --- @private
 function Action:__validateTargets(level)
    if #self.targets < #self.targetObjects then
-      return false, string.format("Expected %s targets got %s targets for action %s", #self.targets, #self.targetObjects, self.className)
+      return false,
+         string.format(
+            "Expected %s targets got %s targets for action %s",
+            #self.targets,
+            #self.targetObjects,
+            self.className
+         )
    end
 
    local previousTargets = {}
@@ -81,10 +87,10 @@ function Action:perform(level, ...)
    error("This is a virtual method and must be overriden by subclasses!")
 end
 
---- Returns the target actor at the specified index.
----@param n number The index of the target actor to retrieve.
----@return any target The target actor at the specified index.
-function Action:getTarget(n)
+--- Returns the targeted object at the specified index.
+---@param n number The index of the targeted object to retrieve.
+---@return any target The targeted object at the specified index.
+function Action:getTargeted(n)
    if self.targetObjects[n] then return self.targetObjects[n] end
 end
 
@@ -95,17 +101,17 @@ function Action:getNumTargets()
    return #self.targets
 end
 
---- Returns the target object at the specified index.
---- @param index number The index of the target object to retrieve.
---- @return Target|nil targetObject
-function Action:getTargetObject(index)
+--- Returns the target at the specified index.
+--- @param index number The index of the target to retrieve.
+--- @return Target? targetObject
+function Action:getTarget(index)
    return self.targets[index]
 end
 
 --- Determines if the specified actor is a target of this action.
 --- @param actor Actor The actor to check if they are a target of this action.
 --- @return boolean -- True if the specified actor is a target of this action, false otherwise.
-function Action:hasTarget(actor)
+function Action:hasTargeted(actor)
    for _, a in pairs(self.targetObjects) do
       if a == actor then return true end
    end

--- a/engine/core/decisions/actiondecision.lua
+++ b/engine/core/decisions/actiondecision.lua
@@ -15,18 +15,12 @@ function ActionDecision:validateResponse()
    return self.action ~= nil
 end
 
---- Sets an action. It must be valid, i.e. :lua:func:`Level.canPerform` returns true.
---- @param action Action A valid action.
-function ActionDecision:setAction(action)
-   self.action = action
-end
-
 --- Sets an action if it can be performed and there is not an action set already.
 --- @param action Action An action to try setting.
 --- @param level Level The level.
 --- @return boolean set True if the action was set, false otherwise.
 --- @return string? err An error message if setting the action failed.
-function ActionDecision:trySetAction(action, level)
+function ActionDecision:setAction(action, level)
    if self.action then return false, "ActionDecision already has an action!" end
 
    local can, err = level:canPerform(action)


### PR DESCRIPTION
Breaking changes to improve UX and clarity around the `ActionDecision` and target API. Referring to the objects corresponding to targets as `targeted`.

Maybe put this to the `1.0` branch I made, but unsure how releases are going to go down.