### PR TITLE
feat: improve and rename MapBuilder

### DIFF
--- a/docs/source/how-tos/query.rst
+++ b/docs/source/how-tos/query.rst
@@ -9,7 +9,7 @@ Basic usage
 -----------
 
 To start a query, call :lua:func:`IQueryable.query` with the component types you want to require.
-This interface is implemented by :lua:class:`Level`, :lua:class:`MapBuilder`, and
+This interface is implemented by :lua:class:`Level`, :lua:class:`LevelBuilder`, and
 :lua:class:`ActorStorage`.
 
 .. code-block:: lua

--- a/docs/source/making-a-roguelike/part2.rst
+++ b/docs/source/making-a-roguelike/part2.rst
@@ -164,11 +164,11 @@ ahead and add ``prism.systems.Fall()`` to the bottom of the list like so.
 
 .. code-block:: lua
 
-   local level = prism.Level(map, actors, {
+   builder:addSystems(
       prism.systems.Senses(),
       prism.systems.Sight(),
-      prism.systems.Fall(),
-   })
+      prism.systems.Fall()
+   )
 
 Wrapping up
 -----------

--- a/docs/source/making-a-roguelike/part7.rst
+++ b/docs/source/making-a-roguelike/part7.rst
@@ -19,7 +19,7 @@ from this module that takes a few parameters.
    --- @param width integer
    --- @param height integer
    return function(rng, player, width, height)
-      local builder = prism.MapBuilder(prism.cells.Wall)
+      local builder = prism.LevelBuilder(prism.cells.Wall)
 
       -- world building code goes here!
 
@@ -28,7 +28,7 @@ from this module that takes a few parameters.
 
 We give the level building function an :lua:class:`RNG` which will be exclusive to it, the player we
 want to place, and the width and height of the map we want generated. Inside we create a
-:lua:class:`MapBuilder` and return it. The constant ``PARTITIONS`` will define the grid size of the
+:lua:class:`LevelBuilder` and return it. The constant ``PARTITIONS`` will define the grid size of the
 rooms.
 
 Populating the void
@@ -93,7 +93,7 @@ After that let's set some reasonable limits on the minimum and maximum room widt
 
 Next we loop through each of our partitions and build a room so long as it's not the one we're
 omitting. We create a :lua:class:`Rectangle`, hash its partition coordinates, and put it into our
-table of rooms. Finally we draw the room onto our map with :lua:func:`MapBuilder.drawRectangle`.
+table of rooms. Finally we draw the room onto our map with :lua:func:`LevelBuilder.drawRectangle`.
 
 .. code-block:: lua
 
@@ -133,11 +133,11 @@ should start vertically or horizontally for a little bit of spice.
       local bx, by = b:center():floor():decompose()
       -- Randomly choose one of two L-shaped tunnel patterns for variety.
       if rng:random() > 0.5 then
-         builder:drawLine(ax, ay, bx, ay, prism.cells.Floor)
-         builder:drawLine(bx, ay, bx, by, prism.cells.Floor)
+         builder:line(ax, ay, bx, ay, prism.cells.Floor)
+         builder:line(bx, ay, bx, by, prism.cells.Floor)
       else
-         builder:drawLine(ax, ay, ax, by, prism.cells.Floor)
-         builder:drawLine(ax, by, bx, by, prism.cells.Floor)
+         builder:line(ax, ay, ax, by, prism.cells.Floor)
+         builder:line(ax, by, bx, by, prism.cells.Floor)
       end
    end
 
@@ -191,7 +191,7 @@ Sending it back
 
    return builder
 
-Finally we'll pad the entire map in some walls and return the finished :lua:class:`MapBuilder`.
+Finally we'll pad the entire map in some walls and return the finished :lua:class:`LevelBuilder`.
 
 .. dropdown:: Complete levelgen.lua
 
@@ -204,7 +204,7 @@ Finally we'll pad the entire map in some walls and return the finished :lua:clas
       --- @param width integer
       --- @param height integer
       return function(rng, player, width, height)
-         local builder = prism.MapBuilder(prism.cells.Wall)
+         local builder = prism.LevelBuilder(prism.cells.Wall)
 
          -- Fill the map with random noise of pits and walls.
          local nox, noy = rng:random(1, 10000), rng:random(1, 10000)
@@ -249,11 +249,11 @@ Finally we'll pad the entire map in some walls and return the finished :lua:clas
             local bx, by = b:center():floor():decompose()
             -- Randomly choose one of two L-shaped tunnel patterns for variety.
             if rng:random() > 0.5 then
-               builder:drawLine(ax, ay, bx, ay, prism.cells.Floor)
-               builder:drawLine(bx, ay, bx, by, prism.cells.Floor)
+               builder:line(ax, ay, bx, ay, prism.cells.Floor)
+               builder:line(bx, ay, bx, by, prism.cells.Floor)
             else
-               builder:drawLine(ax, ay, ax, by, prism.cells.Floor)
-               builder:drawLine(ax, by, bx, by, prism.cells.Floor)
+               builder:line(ax, ay, ax, by, prism.cells.Floor)
+               builder:line(ax, by, bx, by, prism.cells.Floor)
             end
          end
 
@@ -311,5 +311,5 @@ Descending to the next part
 ---------------------------
 
 We've developed a simple level generation algorithm using :lua:class:`RNG` and
-:lua:class:`MapBuilder`. In the :doc:`next section <part8>` of the tutorial we'll add a set of
+:lua:class:`LevelBuilder`. In the :doc:`next section <part8>` of the tutorial we'll add a set of
 stairs and let the player descend deeper into the dungeon!

--- a/docs/source/making-a-roguelike/part9.rst
+++ b/docs/source/making-a-roguelike/part9.rst
@@ -64,7 +64,7 @@ generation ensures that the game will be repeatable given the same seed.
    end
 
    --- @param player Actor
-   --- @return MapBuilder builder
+   --- @return LevelBuilder builder
    function Game:generateNextFloor(player)
       self.depth = self.depth + 1
 
@@ -91,20 +91,19 @@ Next we'll change ``GameLevelState``'s constructor.
 .. code-block:: lua
 
    --- @param display Display
-   --- @param builder MapBuilder
+   --- @param builder LevelBuilder
    --- @param seed string
    function GameLevelState:__new(display, builder, seed)
-      -- Build the map and instantiate the level with systems
-      local map, actors = builder:build()
-      local level = prism.Level(map, actors, {
+      builder:addSystems(
          prism.systems.Senses(),
          prism.systems.Sight(),
          prism.systems.Fall(),
-      }, nil, seed)
+      )
+      builder:addSeed(seed)
 
       -- Initialize with the created level and display, the heavy lifting is done by
       -- the parent class.
-      spectrum.LevelState.__new(self, level, display)
+      spectrum.LevelState.__new(self, builder:build(), display)
    end
 
 This sets up our level with the map we build and the seed we'll pass from the ``Game``. Let's change
@@ -112,7 +111,7 @@ our overload here as well to reflect the new arguments.
 
 .. code-block:: lua
 
-   --- @overload fun(display: Display, builder: MapBuilder, seed: string): GameLevelState
+   --- @overload fun(display: Display, builder: LevelBuilder, seed: string): GameLevelState
    local GameLevelState = spectrum.LevelState:extend "GameLevelState"
 
 Now modify our message handler so it passes the player into the next level:

--- a/engine/core/rng.lua
+++ b/engine/core/rng.lua
@@ -34,7 +34,7 @@ local function createMash()
 end
 
 --- Initializes a new RNG instance.
---- @param seed any The seed for the RNG (optional).
+--- @param seed any The seed for the RNG.
 function RNG:__new(seed)
    assert(seed, "A seed must be provided to instantiate an RNG!")
    assert(tostring(seed), "Seed must be a string or implement __tostring!")

--- a/engine/init.lua
+++ b/engine/init.lua
@@ -125,8 +125,8 @@ prism.RNG = prism.require "core.rng"
 prism.System = prism.require "core.system"
 --- @module "engine.core.system_manager"
 prism.SystemManager = prism.require "core.system_manager"
---- @module "engine.core.map_builder"
-prism.MapBuilder = prism.require "core.map_builder"
+--- @module "engine.core.levelbuilder"
+prism.LevelBuilder = prism.require "core.levelbuilder"
 --- @module "engine.core.map"
 prism.Map = prism.require "core.map"
 --- @module "engine.core.message"
@@ -416,13 +416,13 @@ end
 
 function prism.hotload() end
 
---- This is the core turn logic, and if you need to use a different scheduler or want a different turn structure you should override this.
---- There is a version of this provided for time-based
----@param level Level
----@param actor Actor
----@param controller Controller
----@diagnostic disable-next-line
-function prism.turn(level, actor, controller)
+--- @alias TurnHandler fun(level: Level, actor: Actor, controller: Controller)
+
+--- This is the default core turn logic. Use :lua:func:`LevelBuilder.addTurnHandler` to override this.
+--- @param level Level
+--- @param actor Actor
+--- @param controller Controller
+function prism.defaultTurn(level, actor, controller)
    local action = controller:act(level, actor)
 
    -- we make sure we got an action back from the controller for sanity's sake

--- a/geometer/gamestates/editorstate.lua
+++ b/geometer/gamestates/editorstate.lua
@@ -10,7 +10,7 @@ local keybindings = require "keybindingschema"
 local EditorState = spectrum.GameState:extend "EditorState"
 
 --- Create a new Editor managing gamestate, attached to a
---- SpectrumAttachable, this is a Level|MapBuilder interface.
+--- SpectrumAttachable, this is a Level|LevelBuilder interface.
 --- @param attachable SpectrumAttachable
 function EditorState:__new(attachable, display, fileEnabled)
    self.editor = geometer.Editor(attachable, display, fileEnabled)
@@ -53,7 +53,10 @@ function EditorState:mousereleased(x, y, button)
 end
 
 function EditorState:keypressed(key, scancode)
-   if keybindings:keypressed(key) == "close editor" then self.manager:pop() return end
+   if keybindings:keypressed(key) == "close editor" then
+      self.manager:pop()
+      return
+   end
    self.editor:keypressed(key, scancode)
 end
 

--- a/geometer/gamestates/mapgenerator.lua
+++ b/geometer/gamestates/mapgenerator.lua
@@ -1,10 +1,10 @@
 --- A wrapper around Geometer's EditorState meant for stepping through map generation.
 --- @class MapGeneratorState : EditorState
---- @overload fun(generator: function, builder: MapBuilder, display: Display): MapGeneratorState
+--- @overload fun(generator: function, builder: LevelBuilder, display: Display): MapGeneratorState
 local MapGeneratorState = geometer.EditorState:extend "MapGeneratorState"
 
 --- @param generator function
---- @param builder MapBuilder
+--- @param builder LevelBuilder
 --- @param display Display
 function MapGeneratorState:__new(generator, builder, display)
    geometer.EditorState.__new(self, builder, display)

--- a/geometer/gamestates/prefabeditor.lua
+++ b/geometer/gamestates/prefabeditor.lua
@@ -2,7 +2,7 @@
 local PrefabEditorState = geometer.EditorState:extend "PrefabEditorState"
 
 function PrefabEditorState:__new(mb)
-   local attachable = mb or prism.MapBuilder()
+   local attachable = mb or prism.LevelBuilder()
    local spriteAtlas =
       spectrum.SpriteAtlas.fromGrid("example_srd/display/wanderlust_16x16.png", 16, 16)
    local display = spectrum.Display(spriteAtlas, prism.Vector2(16, 16), attachable)

--- a/geometer/modifications/erase.lua
+++ b/geometer/modifications/erase.lua
@@ -22,7 +22,7 @@ function EraseModification:execute(attachable)
 
    for x = i, k do
       for y = j, l do
-         if prism.MapBuilder:is(attachable) then self:placeCell(attachable, x, y, nil) end
+         if prism.LevelBuilder:is(attachable) then self:placeCell(attachable, x, y, nil) end
          for actor in attachable:query():at(x, y):iter() do
             self:removeActor(attachable, actor)
          end

--- a/geometer/modifications/unfloatselection.lua
+++ b/geometer/modifications/unfloatselection.lua
@@ -1,8 +1,8 @@
 --- @class UnfloatSelectionModification : Modification
 --- @field placeable Placeable
 --- @field position Vector2
---- @field floatingSelection MapBuilder
---- @overload fun(placeable: Placeable, position: Vector2, floatingSelection: MapBuilder)
+--- @field floatingSelection LevelBuilder
+--- @overload fun(placeable: Placeable, position: Vector2, floatingSelection: LevelBuilder)
 --- @type UnfloatSelectionModification
 local UnfloatSelection = geometer.Modification:extend "UnfloatSelectionModification"
 


### PR DESCRIPTION
Big breaking change but a big improvement. `MapBuilder` renamed to `LevelBuilder` and added the additional settings for configuring a level. Also includes support for a custom turn handler per-level. Renamed and added fill / line support to the map drawing functions.

```lua
   local builder = prism.LevelBuilder(prism.cells.Wall) -- or prism.Level.builder(prism.Cells.Wall)
   builder:ellipse("fill", 5, 5, 10, 10, prism.cells.Floor)
   builder:addSystems(
      prism.systems.Senses(),
      prism.systems.Sight(),
      prism.systems.Fall(),
      prism.systems.Tick()
   )
   builder:addSeed(seed)
   local level = builder:build()
```

Fixes #145 and replaces #162 