### PR TITLE
If a file does not return an Object before registration, print its name.

### DIFF
--- a/engine/init.lua
+++ b/engine/init.lua
@@ -355,6 +355,9 @@ local function loadRegistry(path, registry, recurse, definitions)
          local item = require(requireName)
 
          if not registry.manualRegistration then
+            if not prism.Object:is(item) then
+               error(requireName .. " does not return a factory!")
+            end
             prism.register(item, true)
             local objectName = item.className
             prism.writeDefinitions(


### PR DESCRIPTION
This is the change I shared on Discord -- useful for dummies like me who consistently forget to return the object at the bottom of each file but aren't sure which file is missing it.

This check for Object-hood also happens immediately below inside of `prism.register` so it shouldn't change any logic flows.